### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly-deploy.yaml
+++ b/.github/workflows/nightly-deploy.yaml
@@ -1,4 +1,5 @@
 name: Nightly Deploy
+permissions: none
 
 on:
   workflow_dispatch: 


### PR DESCRIPTION
Potential fix for [https://github.com/jsmith97/scalablepath/security/code-scanning/1](https://github.com/jsmith97/scalablepath/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` permissions to the minimum required. Since the workflow only triggers an external Netlify build hook and does not interact with the GitHub API, the best practice is to set `permissions: none` at the workflow level. This ensures that the `GITHUB_TOKEN` is not granted any permissions, adhering to the principle of least privilege. The change should be made at the top level of `.github/workflows/nightly-deploy.yaml`, immediately after the `name` field and before the `on` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
